### PR TITLE
changes with job execution and clientserver timeout

### DIFF
--- a/installer/current.version
+++ b/installer/current.version
@@ -1,5 +1,5 @@
 # current.version: (1) app-version, (2) release-number, (3) build-number.  order is important.  this line must remain.
-genii.app-version=2.7.647
+genii.app-version=2.7.648
 genii.release-number=1
 genii.build-number=9922
 

--- a/libraries/ProcessWrapper/trunk/src/OSSpecific-unix.c
+++ b/libraries/ProcessWrapper/trunk/src/OSSpecific-unix.c
@@ -110,8 +110,11 @@ int dumpStats() {
 
 void sig_handler(int signo)
 {
-	if (signo == SIGTERM || signo == SIGCHLD) {
+	if (signo == SIGTERM) {
 		beingKilled=1;
+		dumpStats();
+	}
+	else if (signo == SIGCHLD) {
 		dumpStats();
 	}
 
@@ -223,8 +226,9 @@ int wrapJob(CommandLine *commandLine)
 	int ticks=0;
 	while (running==1 && beingKilled==0) {
 		// 2020-06-05 by ASG .. change the order to dumpstats first, then sleep
-		exitCode=dumpStats();
-		sleep(SLEEP_DURATION);
+		if ((ticks % SLEEP_DURATION) == 0)
+			exitCode=dumpStats();
+		sleep(1);
 		ticks++;
 	}
 	// End of updates

--- a/libraries/gffs-basics/trunk/src/org/morgan/ftp/FTPConfiguration.java
+++ b/libraries/gffs-basics/trunk/src/org/morgan/ftp/FTPConfiguration.java
@@ -13,7 +13,7 @@ public class FTPConfiguration
 	public FTPConfiguration(int listenPort)
 	{
 		_listenPort = listenPort;
-		_idleTimeoutSeconds = 150;
+		_idleTimeoutSeconds = 21600;
 		_dataConnectionTimeout = 60;
 		_missedAuthenticationsLimit = 3;
 

--- a/src/edu/virginia/vcgr/genii/container/bes/execution/phases/QueueProcessPhase.java
+++ b/src/edu/virginia/vcgr/genii/container/bes/execution/phases/QueueProcessPhase.java
@@ -161,6 +161,15 @@ public class QueueProcessPhase extends AbstractRunProcessPhase implements Termin
 		String userName = CredentialWallet.extractUsername(owner);
 		if (userName == null)
 			userName = "UnKnown";
+		
+		// CCH 2020 June 24
+		// POSIX Applications don't set these fields and cause a null pointer exception later if we don't set defaults
+		if (_numProcesses == null)
+			_numProcesses = 1;
+		if (_numProcessesPerHost == null)
+			_numProcessesPerHost = 1;
+		if (_threadsPerProcess == null) 
+			_threadsPerProcess = 1;
 
 		// End of updates
 
@@ -207,6 +216,17 @@ public class QueueProcessPhase extends AbstractRunProcessPhase implements Termin
                 }
                 // End jobName updates
                 resourceUsageFile =tmp.getNewResourceUsageFile();  // This should point to the accounting directory, not create a properties file.
+				if (_logger.isDebugEnabled()) {
+					_logger.debug("Generate Properties Constructor tmp: " + tmp);
+					_logger.debug("Generate Properties Constructor userName: " + userName);
+					_logger.debug("Generate Properties Constructor _executable (File): " + _executable);
+					_logger.debug("Generate Properties Constructor _executable.getAbsolutePath (String): " + _executable.getAbsolutePath());
+					_logger.debug("Generate Properties Constructor _memory: " + _memory);
+					_logger.debug("Generate Properties Constructor _numProcesses: " + _numProcesses);
+					_logger.debug("Generate Properties Constructor _numProcessesPerHost: " + _numProcessesPerHost);
+					_logger.debug("Generate Properties Constructor _threadsPerProcess: " + _threadsPerProcess);
+					_logger.debug("Generate Properties Constructor _jobName: " + _jobName);
+				}
 				generateProperties(tmp,userName,_executable.getAbsolutePath(), _memory, _numProcesses,
 						_numProcessesPerHost, _threadsPerProcess, _jobName );
 

--- a/src/edu/virginia/vcgr/genii/container/bes/execution/phases/QueueProcessPhase.java
+++ b/src/edu/virginia/vcgr/genii/container/bes/execution/phases/QueueProcessPhase.java
@@ -165,11 +165,11 @@ public class QueueProcessPhase extends AbstractRunProcessPhase implements Termin
 		// CCH 2020 June 24
 		// POSIX Applications don't set these fields and cause a null pointer exception later if we don't set defaults
 		if (_numProcesses == null)
-			_numProcesses = 1;
+			_numProcesses = new Integer(1);
 		if (_numProcessesPerHost == null)
-			_numProcessesPerHost = 1;
+			_numProcessesPerHost = new Integer(1);
 		if (_threadsPerProcess == null) 
-			_threadsPerProcess = 1;
+			_threadsPerProcess = new Integer(1);
 
 		// End of updates
 


### PR DESCRIPTION
- Fix jobs failing with a null pointer exception if they were POSIX jobs rather than SPMD.
- Fix jobs running for at least 6 minutes.
- Increase FTPConfiguration idletimeout to 6 hours, which is reused for the clientserver, to allow for longer uploads.