### PR TITLE
Add image job unit tests

### DIFF
--- a/src/edu/virginia/vcgr/genii/container/bes/execution/phases/CheckBinariesPhase.java
+++ b/src/edu/virginia/vcgr/genii/container/bes/execution/phases/CheckBinariesPhase.java
@@ -119,7 +119,7 @@ public class CheckBinariesPhase extends AbstractExecutionPhase implements Serial
 			for (MessageElement child : resp.get_any()) {
 				document.addChild(child);
 			}
-			String sourceLastModified = document.toString().split("<ns32:ModificationTime")[1].split(">")[1].split("<")[0];
+			String sourceLastModified = document.toString().split("ModificationTime")[1].split(">")[1].split("<")[0];
 			
 			// Get target last modified time (in local FS)
 			String targetLastModified = Files.readAttributes(target.toPath(), BasicFileAttributes.class).lastModifiedTime().toString();

--- a/src/edu/virginia/vcgr/genii/container/bes/execution/phases/RunProcessPhase.java
+++ b/src/edu/virginia/vcgr/genii/container/bes/execution/phases/RunProcessPhase.java
@@ -202,6 +202,12 @@ public class RunProcessPhase extends AbstractRunProcessPhase implements Terminat
 			}
 			for (String arg : _arguments)
 				command.add(arg);
+			
+			if (_logger.isDebugEnabled()) {
+				_logger.debug("The following is the command line sent to the pwrapper:");
+				for (String c : command)
+					_logger.debug(c);
+			}
 
 			File workingDirectory = context.getCurrentWorkingDirectory().getWorkingDirectory();
 
@@ -233,9 +239,9 @@ public class RunProcessPhase extends AbstractRunProcessPhase implements Terminat
 			stderrFile = _redirects.stderrSink(workingDirectory);
 
 			// assemble job properties for cmdline manipulators
-			Collection<String> args = new ArrayList<String>(_arguments.length);
-			for (String s : _arguments)
-				args.add(s);
+			Collection<String> args = new ArrayList<String>(command.size()-1);
+			for (int i = 1; i < command.size(); i++)
+				args.add(command.get(i));
 
 			// old code
 			// File resourceUsageFile = new ResourceUsageDirectory(workingDirectory).getNewResourceUsageFile();
@@ -297,7 +303,7 @@ public class RunProcessPhase extends AbstractRunProcessPhase implements Terminat
 			hWriter.close();
 			_logger.info(String.format("Executing job for userID '%s' using command line:\n\t%s", userName, testCmdLine.toString()));
 
-			token = wrapper.execute(_fuseMountPoint, _environment, workingDirectory, _redirects.stdinSource(), resourceUsageFile, newCmdLine);
+			token = wrapper.execute(_fuseMountPoint, _environment, workingDirectory, _redirects.stdinSource(), resourceUsageFile, testCmdLine);
 			// ASG - TEST code remove if found
 			_process=token;
 			// End test

--- a/src/edu/virginia/vcgr/genii/container/bes/execution/phases/RunProcessPhase.java
+++ b/src/edu/virginia/vcgr/genii/container/bes/execution/phases/RunProcessPhase.java
@@ -145,6 +145,7 @@ public class RunProcessPhase extends AbstractRunProcessPhase implements Terminat
 		// End of updates
 
 		synchronized (_processLock) {
+			File workingDirectory = context.getCurrentWorkingDirectory().getWorkingDirectory();
 			command = new Vector<String>();
 
 			// 2020 May 26 CCH, if executable is an image, we set the new executable to be the appropriate wrapper and push the image path into the arguments
@@ -171,6 +172,7 @@ public class RunProcessPhase extends AbstractRunProcessPhase implements Terminat
 				else {
 					execName = "../singularity-wrapper.sh";
 				}
+				_executable = new File(workingDirectory, execName);
 				if (_logger.isDebugEnabled())
 					_logger.debug("Handling image executable: " + execName);
 					_logger.debug("Adding executable: " + execName);
@@ -208,8 +210,6 @@ public class RunProcessPhase extends AbstractRunProcessPhase implements Terminat
 				for (String c : command)
 					_logger.debug(c);
 			}
-
-			File workingDirectory = context.getCurrentWorkingDirectory().getWorkingDirectory();
 
 			ProcessWrapper wrapper = ProcessWrapperFactory.createWrapper(_commonDirectory);
 
@@ -303,7 +303,7 @@ public class RunProcessPhase extends AbstractRunProcessPhase implements Terminat
 			hWriter.close();
 			_logger.info(String.format("Executing job for userID '%s' using command line:\n\t%s", userName, testCmdLine.toString()));
 
-			token = wrapper.execute(_fuseMountPoint, _environment, workingDirectory, _redirects.stdinSource(), resourceUsageFile, testCmdLine);
+			token = wrapper.execute(_fuseMountPoint, _environment, workingDirectory, _redirects.stdinSource(), resourceUsageFile, newCmdLine);
 			// ASG - TEST code remove if found
 			_process=token;
 			// End test

--- a/toolkit/tests/EMS_Tests/imageJobTests/image-job-test.sh
+++ b/toolkit/tests/EMS_Tests/imageJobTests/image-job-test.sh
@@ -9,6 +9,19 @@ cd "$WORKDIR"
 if [ -z "$GFFS_TOOLKIT_SENTINEL" ]; then echo Please run prepare_tools.sh before testing.; exit 3; fi
 source "$GFFS_TOOLKIT_ROOT/library/establish_environment.sh"
 
+getAdminCredentials()
+{
+	grid login /users/xsede.org/admin --username=admin --password=admin
+}
+
+dropAdminCredentials()
+{
+	grid logout --pattern=admin
+	grid logout --pattern=gffs-users
+	grid logout --pattern=gffs-amie
+	grid login /groups/xsede.org/gffs-users --username=gffs-users --password=""
+}
+
 oneTimeSetUp()
 {
   sanity_test_and_init  # make sure test environment is good.
@@ -26,14 +39,11 @@ oneTimeSetUp()
   grid cp local:$PWD/inside-container.sh grid:$RNSPATH
 
 	echo "Logging into admin to create directories"
-	grid login /users/xsede.org/admin --username=admin --password=admin
+	getAdminCredentials
 	echo "Adding image to Images userX's Image dir"
 	grid mkdir -p /home/CCC/Lancium/userX/Images
-	grid chmod -R /home/CCC/ +rw /users/xsede.org/userX
-	grid logout --pattern=admin
-	grid logout --pattern=gffs-users
-	grid logout --pattern=gffs-aime
-	grid login /groups/xsede.org/gffs-users --username=gffs-users --password=""
+	grid chmod -R /home/CCC +rwx /users/xsede.org/userX
+	dropAdminCredentials
   grid cp local:$PWD/ubuntu18.04.simg grid:/home/CCC/Lancium/userX/Images/ubuntu18.04.simg
 
 	echo "Adding local FS Images dir"
@@ -62,7 +72,9 @@ testImageJob()
 oneTimeTearDown()
 {
   echo tearing down test.
+	getAdminCredentials
 	grid rm -r /home/CCC
+	dropAdminCredentials
 	rm -r ~/.genesisII-2.0/bes-activities/Images
 }
 

--- a/toolkit/tests/EMS_Tests/imageJobTests/image-job-test.sh
+++ b/toolkit/tests/EMS_Tests/imageJobTests/image-job-test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+#Author: Vanamala Venkataswamy
+#mods: Chris Koeritz, Charlie Houghton
+
+export WORKDIR="$( \cd "$(\dirname "$0")" && \pwd )"  # obtain the script's working directory.
+cd "$WORKDIR"
+
+if [ -z "$GFFS_TOOLKIT_SENTINEL" ]; then echo Please run prepare_tools.sh before testing.; exit 3; fi
+source "$GFFS_TOOLKIT_ROOT/library/establish_environment.sh"
+
+oneTimeSetUp()
+{
+  sanity_test_and_init  # make sure test environment is good.
+
+  create_jsdl_from_templates  # turn template files into the real jsdl.
+  if [ $? -ne 0 ]; then
+    echo "JSDL file generation failure.  unassigned random id perhaps?"
+    exit 1
+  fi
+
+	echo "Adding singularity-wrapper.sh"
+	cp singularity-wrapper.sh ~/.genesisII-2.0/bes-activities/
+
+  echo "Copying necessary file to Grid namespace:" $RNSPATH
+  grid cp local:$PWD/inside-container.sh grid:$RNSPATH
+
+	echo "Logging into admin to create directories"
+	grid login /users/xsede.org/admin --username=admin --password=admin
+	echo "Adding image to Images userX's Image dir"
+	grid mkdir -p /home/CCC/Lancium/userX/Images
+	grid chmod -R /home/CCC/ +rw /users/xsede.org/userX
+	grid logout --pattern=admin
+	grid logout --pattern=gffs-users
+	grid logout --pattern=gffs-aime
+	grid login /groups/xsede.org/gffs-users --username=gffs-users --password=""
+  grid cp local:$PWD/ubuntu18.04.simg grid:/home/CCC/Lancium/userX/Images/ubuntu18.04.simg
+
+	echo "Adding local FS Images dir"
+	mkdir -p ~/.genesisII-2.0/bes-activities/Images/userX/
+}
+
+testQueueResourcesExist()
+{
+  available_resources="$(get_BES_resources)"
+  assertEquals "Listing $QUEUE_PATH/resources" 0 $?
+}
+
+testImageJob()
+{
+	submit="$(grid qsub $QUEUE_PATH local:$GENERATED_JSDL_FOLDER/image-job.jsdl)"
+	assertEquals "Submitting single job that we intend to terminate in 30 seconds with file staging from GFFS using OGSA BYTE/IO protocol" 0 $?
+	echo "Waiting 60 seconds for job to finish and data to be staged out."
+	sleep 60
+	grid ls grid:$RNSPATH
+	grid cat grid:$RNSPATH/image-job.out
+	hostname_sleep_output="$(grid cat grid:$RNSPATH/image-job.out)"
+	echo $hostname_sleep_output | grep -q "args: /bin/bash inside-container.sh"
+	assertEquals "Image job should be using the wrapper and have the arguments /bin/bash inside-container.sh." 0 $?
+}
+
+oneTimeTearDown()
+{
+  echo tearing down test.
+	grid rm -r /home/CCC
+	rm -r ~/.genesisII-2.0/bes-activities/Images
+}
+
+# load and run shUnit2
+source "$SHUNIT_DIR/shunit2"
+

--- a/toolkit/tests/EMS_Tests/imageJobTests/image-job.jsdl
+++ b/toolkit/tests/EMS_Tests/imageJobTests/image-job.jsdl
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<JobDefinition xmlns="http://schemas.ggf.org/jsdl/2005/11/jsdl" xmlns:ns2="http://schemas.ggf.org/jsdl/2005/11/jsdl-posix" xmlns:ns3="http://schemas.ggf.org/jsdl/2006/07/jsdl-hpcpa" xmlns:ns4="http://schemas.ogf.org/jsdl/2007/02/jsdl-spmd" xmlns:ns5="http://vcgr.cs.virginia.edu/jsdl/genii" xmlns:ns6="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:ns7="http://schemas.ogf.org/hpcp/2007/11/ac" xmlns:ns8="http://schemas.ogf.org/jsdl/2009/03/sweep" xmlns:ns9="http://schemas.ogf.org/jsdl/2009/03/sweep/functions">
+    <JobDescription>
+        <JobIdentification>
+            <JobName>image-job-test</JobName>
+        </JobIdentification>
+        <Application>
+            <ns2:POSIXApplication>
+                <ns2:Executable>ubuntu18.04.simg</ns2:Executable>
+								<ns2:Argument>/bin/bash</ns2:Argument>
+                <ns2:Argument>inside-container.sh</ns2:Argument>
+                <ns2:Output>image-job.out</ns2:Output>
+                <ns2:Error>image-job.err</ns2:Error>
+            </ns2:POSIXApplication>
+        </Application>
+        <DataStaging>
+            <FileName>inside-container.sh</FileName>
+            <CreationFlag>overwrite</CreationFlag>
+            <DeleteOnTermination>true</DeleteOnTermination>
+            <Source>
+                <URI>rns:PATH/inside-container.sh</URI>
+            </Source>
+        </DataStaging>
+        <DataStaging>
+            <FileName>image-job.out</FileName>
+            <CreationFlag>overwrite</CreationFlag>
+            <DeleteOnTermination>true</DeleteOnTermination>
+            <Target>
+                <URI>rns:PATH/image-job.out</URI>
+            </Target>
+        </DataStaging>
+        <DataStaging>
+            <FileName>image-job.err</FileName>
+            <CreationFlag>overwrite</CreationFlag>
+            <DeleteOnTermination>true</DeleteOnTermination>
+            <Target>
+                <URI>rns:PATH/image-job.err</URI>
+            </Target>
+        </DataStaging>
+    </JobDescription>
+</JobDefinition>

--- a/toolkit/tests/EMS_Tests/imageJobTests/inside-container.sh
+++ b/toolkit/tests/EMS_Tests/imageJobTests/inside-container.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo inside container! 

--- a/toolkit/tests/EMS_Tests/imageJobTests/singularity-image-job.jsdl
+++ b/toolkit/tests/EMS_Tests/imageJobTests/singularity-image-job.jsdl
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<JobDefinition xmlns="http://schemas.ggf.org/jsdl/2005/11/jsdl" xmlns:ns2="http://schemas.ggf.org/jsdl/2005/11/jsdl-posix" xmlns:ns3="http://schemas.ggf.org/jsdl/2006/07/jsdl-hpcpa" xmlns:ns4="http://schemas.ogf.org/jsdl/2007/02/jsdl-spmd" xmlns:ns5="http://vcgr.cs.virginia.edu/jsdl/genii" xmlns:ns6="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:ns7="http://schemas.ogf.org/hpcp/2007/11/ac" xmlns:ns8="http://schemas.ogf.org/jsdl/2009/03/sweep" xmlns:ns9="http://schemas.ogf.org/jsdl/2009/03/sweep/functions">
+    <JobDescription>
+        <JobIdentification>
+            <JobName>singularity-image-job-test</JobName>
+        </JobIdentification>
+        <Application>
+            <ns2:POSIXApplication>
+                <ns2:Executable>ubuntu18.04.simg</ns2:Executable>
+								<ns2:Argument>/bin/bash</ns2:Argument>
+                <ns2:Argument>inside-container.sh</ns2:Argument>
+                <ns2:Output>image-job.out</ns2:Output>
+                <ns2:Error>image-job.err</ns2:Error>
+            </ns2:POSIXApplication>
+        </Application>
+        <DataStaging>
+            <FileName>inside-container.sh</FileName>
+            <CreationFlag>overwrite</CreationFlag>
+            <DeleteOnTermination>true</DeleteOnTermination>
+            <Source>
+                <URI>rns:PATH/inside-container.sh</URI>
+            </Source>
+        </DataStaging>
+        <DataStaging>
+            <FileName>image-job.out</FileName>
+            <CreationFlag>overwrite</CreationFlag>
+            <DeleteOnTermination>true</DeleteOnTermination>
+            <Target>
+                <URI>rns:PATH/singularity-image-job.out</URI>
+            </Target>
+        </DataStaging>
+        <DataStaging>
+            <FileName>image-job.err</FileName>
+            <CreationFlag>overwrite</CreationFlag>
+            <DeleteOnTermination>true</DeleteOnTermination>
+            <Target>
+                <URI>rns:PATH/singularity-image-job.err</URI>
+            </Target>
+        </DataStaging>
+    </JobDescription>
+</JobDefinition>

--- a/toolkit/tests/EMS_Tests/imageJobTests/singularity-wrapper.sh
+++ b/toolkit/tests/EMS_Tests/imageJobTests/singularity-wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+image=$1 && shift
+
+echo image: $image, args: $@

--- a/toolkit/tests/EMS_Tests/imageJobTests/singularity-wrapper.sh
+++ b/toolkit/tests/EMS_Tests/imageJobTests/singularity-wrapper.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 image=$1 && shift
 
-echo image: $image, args: $@
+echo singularity-wrapper, image: $image, args: $@

--- a/toolkit/tests/EMS_Tests/imageJobTests/ubuntu18.04.qcow2
+++ b/toolkit/tests/EMS_Tests/imageJobTests/ubuntu18.04.qcow2
@@ -1,0 +1,1 @@
+placeholder image

--- a/toolkit/tests/EMS_Tests/imageJobTests/ubuntu18.04.simg
+++ b/toolkit/tests/EMS_Tests/imageJobTests/ubuntu18.04.simg
@@ -1,0 +1,1 @@
+placeholder image

--- a/toolkit/tests/EMS_Tests/imageJobTests/vm-image-job.jsdl
+++ b/toolkit/tests/EMS_Tests/imageJobTests/vm-image-job.jsdl
@@ -2,11 +2,11 @@
 <JobDefinition xmlns="http://schemas.ggf.org/jsdl/2005/11/jsdl" xmlns:ns2="http://schemas.ggf.org/jsdl/2005/11/jsdl-posix" xmlns:ns3="http://schemas.ggf.org/jsdl/2006/07/jsdl-hpcpa" xmlns:ns4="http://schemas.ogf.org/jsdl/2007/02/jsdl-spmd" xmlns:ns5="http://vcgr.cs.virginia.edu/jsdl/genii" xmlns:ns6="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:ns7="http://schemas.ogf.org/hpcp/2007/11/ac" xmlns:ns8="http://schemas.ogf.org/jsdl/2009/03/sweep" xmlns:ns9="http://schemas.ogf.org/jsdl/2009/03/sweep/functions">
     <JobDescription>
         <JobIdentification>
-            <JobName>image-job-test</JobName>
+            <JobName>vm-image-job-test</JobName>
         </JobIdentification>
         <Application>
             <ns2:POSIXApplication>
-                <ns2:Executable>ubuntu18.04.simg</ns2:Executable>
+                <ns2:Executable>ubuntu18.04.qcow2</ns2:Executable>
 								<ns2:Argument>/bin/bash</ns2:Argument>
                 <ns2:Argument>inside-container.sh</ns2:Argument>
                 <ns2:Output>image-job.out</ns2:Output>
@@ -26,7 +26,7 @@
             <CreationFlag>overwrite</CreationFlag>
             <DeleteOnTermination>true</DeleteOnTermination>
             <Target>
-                <URI>rns:PATH/image-job.out</URI>
+                <URI>rns:PATH/vm-image-job.out</URI>
             </Target>
         </DataStaging>
         <DataStaging>
@@ -34,7 +34,7 @@
             <CreationFlag>overwrite</CreationFlag>
             <DeleteOnTermination>true</DeleteOnTermination>
             <Target>
-                <URI>rns:PATH/image-job.err</URI>
+                <URI>rns:PATH/vm-image-job.err</URI>
             </Target>
         </DataStaging>
     </JobDescription>

--- a/toolkit/tests/EMS_Tests/imageJobTests/vmwrapper.sh
+++ b/toolkit/tests/EMS_Tests/imageJobTests/vmwrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+image=$1 && shift
+
+echo vmwrapper, image: $image, args: $@

--- a/toolkit/tests/regression_test.sh
+++ b/toolkit/tests/regression_test.sh
@@ -115,15 +115,15 @@ GFFS_TESTS=( \
 # 2020-03-20 by ASG. Week two of coronovirus self isolation.
 # Removed protocols tests because filestaging.xcg.virginia.edu no longer exists.
 EMS_TESTS=( \
-  EMS_Tests/queueFunctionalityTests/queue-submission-test.sh \
-  EMS_Tests/performanceTests/queue-performance-test.sh \
-  EMS_Tests/performanceTests/file-staging-performance-test.sh \
-  EMS_Tests/faultJobsTests/bes-submission-sync-fault.sh \
-  EMS_Tests/besStatus/bes-attributes-and-activities.sh \
-  EMS_Tests/fileStagingTests/protocols-test.sh \
+  #EMS_Tests/queueFunctionalityTests/queue-submission-test.sh \
+  #EMS_Tests/performanceTests/queue-performance-test.sh \
+  #EMS_Tests/performanceTests/file-staging-performance-test.sh \
+  #EMS_Tests/faultJobsTests/bes-submission-sync-fault.sh \
+  #EMS_Tests/besStatus/bes-attributes-and-activities.sh \
+  #EMS_Tests/fileStagingTests/protocols-test.sh \
   #EMS_Tests/fileStagingTests/stageout-test.sh \
   EMS_Tests/imageJobTests/image-job-test.sh \
-  EMS_Tests/besFunctionality/bes-submission-test-sync.sh \
+  #EMS_Tests/besFunctionality/bes-submission-test-sync.sh \
 )
 
 #    EMS_Tests/multiUserTests/multiuser-3users-manyjobs.sh \

--- a/toolkit/tests/regression_test.sh
+++ b/toolkit/tests/regression_test.sh
@@ -115,14 +115,15 @@ GFFS_TESTS=( \
 # 2020-03-20 by ASG. Week two of coronovirus self isolation.
 # Removed protocols tests because filestaging.xcg.virginia.edu no longer exists.
 EMS_TESTS=( \
-  EMS_Tests/queueFunctionalityTests/queue-submission-test.sh \
-  EMS_Tests/performanceTests/queue-performance-test.sh \
-  EMS_Tests/performanceTests/file-staging-performance-test.sh \
-  EMS_Tests/faultJobsTests/bes-submission-sync-fault.sh \
-  EMS_Tests/besStatus/bes-attributes-and-activities.sh \
+  #EMS_Tests/queueFunctionalityTests/queue-submission-test.sh \
+  #EMS_Tests/performanceTests/queue-performance-test.sh \
+  #EMS_Tests/performanceTests/file-staging-performance-test.sh \
+  #EMS_Tests/faultJobsTests/bes-submission-sync-fault.sh \
+  #EMS_Tests/besStatus/bes-attributes-and-activities.sh \
   #EMS_Tests/fileStagingTests/protocols-test.sh \
   #EMS_Tests/fileStagingTests/stageout-test.sh \
-  EMS_Tests/besFunctionality/bes-submission-test-sync.sh \
+  EMS_Tests/imageJobTests/image-job-test.sh \
+  #EMS_Tests/besFunctionality/bes-submission-test-sync.sh \
 )
 
 #    EMS_Tests/multiUserTests/multiuser-3users-manyjobs.sh \

--- a/toolkit/tests/regression_test.sh
+++ b/toolkit/tests/regression_test.sh
@@ -115,15 +115,15 @@ GFFS_TESTS=( \
 # 2020-03-20 by ASG. Week two of coronovirus self isolation.
 # Removed protocols tests because filestaging.xcg.virginia.edu no longer exists.
 EMS_TESTS=( \
-  #EMS_Tests/queueFunctionalityTests/queue-submission-test.sh \
-  #EMS_Tests/performanceTests/queue-performance-test.sh \
-  #EMS_Tests/performanceTests/file-staging-performance-test.sh \
-  #EMS_Tests/faultJobsTests/bes-submission-sync-fault.sh \
-  #EMS_Tests/besStatus/bes-attributes-and-activities.sh \
-  #EMS_Tests/fileStagingTests/protocols-test.sh \
+  EMS_Tests/queueFunctionalityTests/queue-submission-test.sh \
+  EMS_Tests/performanceTests/queue-performance-test.sh \
+  EMS_Tests/performanceTests/file-staging-performance-test.sh \
+  EMS_Tests/faultJobsTests/bes-submission-sync-fault.sh \
+  EMS_Tests/besStatus/bes-attributes-and-activities.sh \
+  EMS_Tests/fileStagingTests/protocols-test.sh \
   #EMS_Tests/fileStagingTests/stageout-test.sh \
   EMS_Tests/imageJobTests/image-job-test.sh \
-  #EMS_Tests/besFunctionality/bes-submission-test-sync.sh \
+  EMS_Tests/besFunctionality/bes-submission-test-sync.sh \
 )
 
 #    EMS_Tests/multiUserTests/multiuser-3users-manyjobs.sh \


### PR DESCRIPTION
Added two new unit tests that verify that a job submitted to a Fork/Exec BES with an image executable calls the appropriate wrapper (../singularity-wrapper or ../vmwrapper.sh) with the generated image path ../Images/<userName>/<imageName>, and passing down the remaining arguments. Both the singularity-wrapper.sh, vmwrapper.sh, ubuntu18.04.simg, and ubuntu18.04.qcow2 that are used in the test are placeholders and don't actually run singularity or qemu.

The assumptions we make about running "image jobs" is that the image exists in a known place in the grid: /home/CCC/Lancium/<user>/Images/<imageName>. Part of the test creates that directory, copies an image there, and deletes the directory on cleanup.

Because the above path does not exist and userX does not have privilege to create it or destroy it, we get grid admin credentials (and subsequently drop them) as part of the test. According to `grid whoami`, the credentials are properly reset (only userX and gffs-users appear) after the new image job tests clean up.

The new tests showed me that we had a bug with image jobs submitted to F/E BESes, the executable was not actually being set to the appropriate wrapper. That has also been fixed with the pull request, so the new test should pass.

All regression tests pass.