### PR TITLE
Ls date information

### DIFF
--- a/libraries/gffs-structure/trunk/config/tooldocs/man/ls
+++ b/libraries/gffs-structure/trunk/config/tooldocs/man/ls
@@ -32,3 +32,6 @@ Show a brief summary of the EPR of each RNS entry
  
 Show the certificates associated with each entry
 
+-i | --date-information
+
+Show the date created and date modified of each entry

--- a/src/edu/virginia/vcgr/genii/container/bes/execution/phases/CheckBinariesPhase.java
+++ b/src/edu/virginia/vcgr/genii/container/bes/execution/phases/CheckBinariesPhase.java
@@ -119,7 +119,7 @@ public class CheckBinariesPhase extends AbstractExecutionPhase implements Serial
 			for (MessageElement child : resp.get_any()) {
 				document.addChild(child);
 			}
-			String sourceLastModified = document.toString().split("ModificationTime")[1].split(">")[1].split("<")[0];
+			String sourceLastModified = document.toString().split("ns[0-9][0-9]:ModificationTime")[1].split(">")[1].split("<")[0];
 			
 			// Get target last modified time (in local FS)
 			String targetLastModified = Files.readAttributes(target.toPath(), BasicFileAttributes.class).lastModifiedTime().toString();


### PR DESCRIPTION
Added new flag, -i, to the ls tool. The new flag will display created date and last modified date information in a tabular format similar to the ls -l flag.

Directories as well as files that users do not have permission to view do not display date information and the output will look identical to ls -l output.

All regression tests pass but I haven't updated the man pages yet. Will push new commits to this PR with those changes before merging.